### PR TITLE
Add IsString instance for EitherUrlChunk

### DIFF
--- a/src/Web/Routes/Nested/Types/UrlChunks.hs
+++ b/src/Web/Routes/Nested/Types/UrlChunks.hs
@@ -10,6 +10,7 @@ module Web.Routes.Nested.Types.UrlChunks where
 
 import Data.Attoparsec.Text
 import Text.Regex
+import Data.String (IsString (..))
 import qualified Data.Text as T
 
 
@@ -21,6 +22,9 @@ data EitherUrlChunk (x :: Maybe *) where
 
 l :: T.Text -> EitherUrlChunk 'Nothing
 l = (:=)
+
+instance x ~ 'Nothing => IsString (EitherUrlChunk x) where
+  fromString = l . T.pack
 
 p :: (T.Text, Parser r) -> EitherUrlChunk ('Just r)
 p = (:~)


### PR DESCRIPTION
The naive way to add an `IsString` instance is:

``` haskell
instance IsString (EitherUrlChunk 'Nothing) where
  fromString = l . T.pack
```

This however, doesn't work. Lets consider the literal `"foo"`. In some contexts (e.g. when it is appended to `UrlChunks` with `</>`), only `"foo" :: IsString (EitherUrlChunk x) => EitherUrlChunk x` can be inferred by GHC. So GHC doesn't know that it should use the instance above as there might be instances for `IsString (EitherUrlChunk x)` for other `x`. The solution is to use an equality constraint

``` haskell
instance x ~ 'Nothing => IsString (EitherUrlChunk x) where
  fromString = l . T.pack
```

This tells GHC: `EitherUrlChunk x` is an instance of `IsString`, but `x` has to be `'Nothing`.

I've tested this with this [example code](https://gist.github.com/timjb/d327e97a7111425985bd).

Here's one extra trick that you can use to avoid the `... </> o` at the end of every route declaration:

Change `p` and `r` to

``` haskell
p :: (T.Text, Parser r) -> UrlChunks ['Just r]
p x = Cons ((:~) x) Root
r :: (T.Text, Regex) -> UrlChunks ['Just [String])]
r x = Cons ((:*) x) Root
```

Now generalize `(</>)` to be `++` instead of ':':

``` haskell
(</>) :: EitherUrlChunk wx -> UrlChunks xs -> UrlChunks (wx ++ xs)
```

where `++` is a type-level analogon of `++ :: [a] -> [a] -> [a]` (this can be implemented using type families).

By the way, have you looked at [reroute](http://hackage.haskell.org/package/reroute) (the routing package used by Spock)? Our implementation is very similar to yours.
